### PR TITLE
Fehler bei Ausdrücken in "[]"

### DIFF
--- a/die-grundlagen/exkurs-es2015+.md
+++ b/die-grundlagen/exkurs-es2015+.md
@@ -438,7 +438,7 @@ console.log(user);
 ```javascript
 const nationality = 'german';
 const user = {
-  name: 'Manuel',
+  name: 'Manuel', [nationality]: true
 };
 console.log(user);
 // -> { name: 'Manuel', german: true };


### PR DESCRIPTION
Bei dem 2. Beispiel im Abschnitt "Syntax-Erweiterungen und Vereinfachungen" fehlt der Ausdruck in [].